### PR TITLE
Website: tweak fund style and link

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -5,14 +5,14 @@
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@200;300;400;500;600;700&display=swap');
 
 
- 
+
 /* 01 - Global Style <<<<======================================================>>>>*/
  body {
     font-size: 16px;
     font-family: "Nunito", sans-serif;
     color: #2e3436;
     background: #eeeeec;
-    overflow-x: hidden 
+    overflow-x: hidden
 }
  .top-layer {
     position: relative;
@@ -850,6 +850,9 @@
  .for-mobile {
     display: none;
 }
+ .fund {
+    display: inline-flex;
+ }
 /* 05 */
 /* 06 - Banner Style <<<<======================================================>>>>*/
  .banner-section .side-border {
@@ -1121,7 +1124,7 @@
 }
  .main-services-item {
     position: relative;
-    z-index: 9991 
+    z-index: 9991
 }
  .main-services-item .desing-1 {
     position: absolute;
@@ -1319,7 +1322,7 @@
  }
  .product-section-1 .main-btn {
     color: #fff;
-    background: #40b74c 
+    background: #40b74c
 }
  .product-section-1 p {
     margin-bottom: 30px;
@@ -1368,7 +1371,7 @@
 }
  .product-section-2 .main-btn {
     color: #fff;
-    background: #40b74c 
+    background: #40b74c
 }
  .product-section-2 p {
     margin-bottom: 30px;

--- a/website/templates/header.html
+++ b/website/templates/header.html
@@ -72,11 +72,11 @@
                         </ul>
                         <div class="menu-right-options ms-auto">
                             <p>
-                                <strong class="amount-raised" style="margin-right: 5px;">$</strong> / $5,000 funded
-                                <a href="https://opencollective.com/opensourcebim">
-                                <span class="border-1">
-                                    <span class="progress-bar" id="progress-bar" data-status="0%" aria-label="Progress bar."></span>
-                                </span>
+                                <a href="https://opencollective.com/opensourcebim" target="_blank" title="Fund on Open Collective" class="fund">
+                                    <strong class="amount-raised" style="margin-right: 5px;">$</strong> / $5,000 funded
+                                    <span class="border-1">
+                                        <span class="progress-bar" id="progress-bar" data-status="0%" aria-label="Progress bar."></span>
+                                    </span>
                                 </a>
                             </p>
                             <ul class="social-media-links">


### PR DESCRIPTION
Hi @Moult 

Here's a little style change to the "funding" bit in the header of Bonsai and IfcOpenShell websites.
Hope you're ok with that.

Instead of only having the "growing" bar clickable, now on hover you get :

![web1](https://github.com/user-attachments/assets/dac6a78d-042f-4fb4-a370-9d6655004c80)

Also, sorry for the whitespaces cleanup of my IDE... =D